### PR TITLE
Fix whitespace for user_pw_combinations

### DIFF
--- a/templates/config.yaml.erb
+++ b/templates/config.yaml.erb
@@ -6,9 +6,9 @@ users:
   admin:
     # crypto.createHash('sha1').update(pass).digest('hex')
     password: <%=@conf_admin_pw_hash %>
-<% if @conf_user_pw_combinations != nil %>
-<% @conf_user_pw_combinations.each do |combi|
-         -%><%= combi[0] %>:
+<%- if @conf_user_pw_combinations != nil -%>
+<%- @conf_user_pw_combinations.each do |combi|
+         -%>  <%= combi[0] %>:
     password: <%= combi[1] %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Since whitespace in YAML is significant, the incorrect whitespace
in the user_pw_combinations caused them to be ignored by Verdaccio.