### PR TITLE
Use puppet/nodejs module instead of willdurand/nodejs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": null,
   "issues_url": null,
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppet/nodejs","version_requirement":">= 5.0.0 < 6.0.0"}
   ]
 }
 


### PR DESCRIPTION
The verdaccio module currently relies on version 1.9.x of willdurand/nodejs,
although this is not explicitly specified. In the meantime this branch has
become deprecated and, although there is a 2.0 version, the puppet/nodejs
module has become the 'de facto' standard in the community.

By changing the manifest to use the puppet/nodejs module (and explicitly
stating it as a dependency), it becomes easier for others to use the
verdaccio module and not having it clash with the nodejs module they
are probably already using.