### PR TITLE
Fix module metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
-  "name": "puppet-verdaccio",
+  "name": "verdaccio-verdaccio",
   "version": "0.0.1",
   "author": "Dharmender Singh",
   "summary": "Installing Verdaccio Npm Package",
-  "license": "Apache 2.0",
+  "license": "MIT",
   "source": "github",
   "project_page": null,
   "issues_url": null,


### PR DESCRIPTION
The module name should be specified in the form "vendorname-module",
where vendorname is also the username used for publishing the module
on the forge (https://puppet.com/docs/puppet/5.4/modules_metadata.html).

The license for this module is the MIT license, as indicated in the
LICENSE file and by the package maintainer in
https://github.com/verdaccio/puppet-verdaccio/pull/6#issuecomment-384169448.