### PR TITLE
Custom packages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,51 +36,93 @@ You can also override several configuration parameters.
 
 ```bash
   class { '::verdaccio':
-    install_root       	    => '/usr/local',
-    install_dir        	    => 'verdaccioxy',
-    conf_admin_pw_hash 	    => 'your-pw-hash',
-    conf_port          	    => '8080',
-    daemon_user        	    => 'verdaccioxy',
+    install_root            => '/usr/local',
+    install_dir             => 'verdaccioxy',
+    conf_admin_pw_hash      => 'your-pw-hash',
+    conf_port               => '8080',
+    daemon_user             => 'verdaccioxy',
     conf_listen_to_address  => '127.0.0.1',
     http_proxy              => 'http://proxy.com:3128',
     https_proxy             => 'http://proxy.com:3128',
     conf_template           => 'mymodule/config.yaml.erb',
-    service_template        => 'mymodule/service.erb',    
-    conf_max_body_size	    => '10mb',
-    conf_max_age_in_sec	    => '604800',
-    install_as_service	    => false,
+    service_template        => 'mymodule/service.erb',
+    conf_max_body_size      => '10mb',
+    conf_max_age_in_sec     => '604800',
+    install_as_service      => false,
+    public_npmjs_proxy      => false,
+    url_prefix              => 'https://dev.company.local/sinopia/',
   }
 ```
 
 The default values for all so far configurable parameters are:
 
-```bash  
+```bash
   class { '::verdaccio':
-    install_root       	      => '/opt',
-    install_dir        	      => 'verdaccio',
-    daemon_user        	      => 'verdaccio',
+    install_root              => '/opt',
+    install_dir               => 'verdaccio',
+    daemon_user               => 'verdaccio',
     conf_listen_to_address    => '0.0.0.0',
-    conf_port          	      => '4783',
+    conf_port                 => '4783',
     conf_admin_pw_hash
     conf_user_pw_combinations => undef,
     http_proxy                => '',
     https_proxy               => '',
     conf_template             => 'verdaccio/config.yaml.erb',
     service_template          => 'verdaccio/service.erb',
-    conf_max_body_size	      => '1mb',
-    conf_max_age_in_sec	      => '86400',
-    install_as_service	      => true,
+    conf_max_body_size        => '1mb',
+    conf_max_age_in_sec       => '86400',
+    install_as_service        => true,
+    public_npmjs_proxy        => true,
+    url_prefix                => undef,
   }
 ```
 
+The `public_npmjs_proxy` parameter defaults to `true`, and will result in the following `packages` configuration block in your `config.yaml`:
 
+```
+packages:
+  '*':
+    allow_access: all
+    allow_publish: authenticated
+    proxy: npmjs
+```
 
+Set it to `false` to define your own package settings using `verdaccio::package` (see below):
+
+```
+  class { '::verdaccio':
+    conf_admin_pw_hash => 'your-pw-hash',
+    public_npmjs_proxy => false,
+  }
+```
+
+#### define verdaccio::package
+
+You can customise the `packages` configuration using defined type `verdaccio::package`:
+
+```
+  verdaccio::package {
+    '@public-*/*':
+      allow_access  => 'all',
+      allow_publish => 'authenticated';
+    '@private-*/*':
+      allow_access  => 'authenticated',
+      allow_publish => 'admin',
+    '*':
+      allow_access  => 'all',
+      allow_publish => 'admin',
+      proxy         => 'npmjs',
+      order         => '999';
+  }
+```
+
+The `order` parameter is used by [`puppetlabs-concat`](https://github.com/puppetlabs/puppetlabs-concat) to determine the order in which each package section appears in `config.yaml`.
 
 
 ### Master-Agent-mode installation
 
 In your puppet script for your agent add:
-```bash  
+```bash
   class { 'nodejs':
     # this automatically installs nodejs and npm
     make_default => true,
@@ -95,4 +137,5 @@ In your puppet script for your agent add:
 The module has been tested on the following operating systems. Testing and patches for other platforms are welcome.
 
 * RedHat EL7.
+
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The default values for all so far configurable parameters are:
     install_dir               => 'verdaccio',
     daemon_user               => 'verdaccio',
     conf_listen_to_address    => '0.0.0.0',
-    conf_port          	      => '4873',
+    conf_port                 => '4873',
     conf_admin_pw_hash
     conf_user_pw_combinations => undef,
     http_proxy                => '',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,0 +1,15 @@
+define verdaccio::package (
+  $order         = '001',
+  $install_path  = '/opt/verdaccio',
+  $allow_access  = 'authenticated',
+  $allow_publish = 'admin',
+  $proxy         = 'DEFAULT',
+  $storage       = 'DEFAULT',
+) {
+  $package = $title
+  concat::fragment { "config.yaml > packages > ${package}":
+    target  => "${install_path}/config.yaml",
+    content => template('verdaccio/package.erb'),
+    order   => $order,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
     {"name":"puppet/nodejs","version_requirement":">= 5.0.0 < 6.0.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"}
   ]
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
   "issues_url": null,
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppet/nodejs","version_requirement":">= 5.0.0 < 6.0.0"}
+    {"name":"puppet/nodejs","version_requirement":">= 5.0.0 < 6.0.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"},
   ]
 }
 

--- a/templates/config.yaml.erb
+++ b/templates/config.yaml.erb
@@ -12,47 +12,15 @@ users:
     password: <%= combi[1] %>
 <% end -%>
 <% end -%>
-# a list of other known repositories we can talk to
-uplinks:
-  npmjs:
-    url: https://registry.npmjs.org/
-
-    # amount of time (in milliseconds) to wait for repository to respond
-    # before giving up and use the local cached copy
-    #timeout: 30000
-
-    # maximum time (in seconds) in which data is considered up to date
-    #
-    # default is 2 minutes, so server won't request the same data from
-    # uplink if a similar request was made less than 2 minutes ago
-    #maxage: 120
-    maxage: <%=@conf_max_age_in_sec %>
-
-packages:
-  # uncomment this for packages with "local-" prefix to be available
-  # for admin only, it's a recommended way of handling private packages
-  #'local-*':
-  #  allow_access: admin
-  #  allow_publish: admin
-  #  # you can override storage directory for a group of packages this way:
-  #  storage: 'local_storage'
-
-  '*':
-    # allow all users to read packages ('all' is a keyword)
-    # this includes non-authenticated users
-    allow_access: all
-
-    # allow 'admin' to publish packages
-    allow_publish: admin
-        # if package is not available locally, proxy requests to 'npmjs' registry
-    proxy: npmjs
 
 #####################################################################
 # Advanced settings
 #####################################################################
 
 # if you use nginx with custom path, use this to override links
-#url_prefix: https://dev.company.local/sinopia/
+<% if @url_prefix != nil -%>
+url_prefix: <%= @url_prefix %>
+<% end -%>
 
 # you can specify listen address (or simply a port)
 # listen: localhost:4783
@@ -86,4 +54,21 @@ https_proxy: <%= @https_proxy %>
 # increase it if you have "request entity too large" errors
 #max_body_size: 1mb
 max_body_size: <%=@conf_max_body_size %>
-    
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+    # amount of time (in milliseconds) to wait for repository to respond
+    # before giving up and use the local cached copy
+    #timeout: 30000
+
+    # maximum time (in seconds) in which data is considered up to date
+    #
+    # default is 2 minutes, so server won't request the same data from
+    # uplink if a similar request was made less than 2 minutes ago
+    #maxage: 120
+    maxage: <%=@conf_max_age_in_sec %>
+
+packages:

--- a/templates/package.erb
+++ b/templates/package.erb
@@ -1,0 +1,9 @@
+  '<%= @package %>':
+    allow_access: <%= @allow_access %>
+    allow_publish: <%= @allow_publish %>
+<% if @proxy != 'DEFAULT' -%>
+    proxy: <%= @proxy %>
+<% end -%>
+<% if @storage != 'DEFAULT' -%>
+    storage: <%= @storage %>
+<% end -%>


### PR DESCRIPTION
I needed to customise the `packages` block in `config.yaml`, which the module didn't support. This PR builds `config.yaml` out of fragments using [puppetlabs/puppetlabs-concat](https://github.com/puppetlabs/puppetlabs-concat). It creates one main fragment for the bulk of the config file and allows you to add sections under `packages` with further fragments via a convenience defined type, `verdaccio::package`.

I chose to add `v2.1.0` of `concat` as a dependency simply because that's what I'm already using in my ancient Puppet 3.8.7-based setup. This might not be a good idea for most deployments.