### PR TITLE
correcting indentation

### DIFF
--- a/templates/config.yaml.erb
+++ b/templates/config.yaml.erb
@@ -66,16 +66,16 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
-    # amount of time (in milliseconds) to wait for repository to respond
-    # before giving up and use the local cached copy
-    #timeout: 30000
-	timeout: <%=@time_out %>
+# amount of time (in milliseconds) to wait for repository to respond
+# before giving up and use the local cached copy
+#timeout: 30000
+timeout: <%=@time_out %>
 
-    # maximum time (in seconds) in which data is considered up to date
-    #
-    # default is 2 minutes, so server won't request the same data from
-    # uplink if a similar request was made less than 2 minutes ago
-    #maxage: 120
-    maxage: <%=@conf_max_age_in_sec %>
+# maximum time (in seconds) in which data is considered up to date
+#
+# default is 2 minutes, so server won't request the same data from
+# uplink if a similar request was made less than 2 minutes ago
+#maxage: 120
+maxage: <%=@conf_max_age_in_sec %>
 
 packages:


### PR DESCRIPTION
Service start fails due to bad indentation of a mapping entry