### PR TITLE
Add systemd support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class verdaccio (
   $https_proxy               = '',
   $conf_template             = 'verdaccio/config.yaml.erb',
   $service_template          = 'verdaccio/service.erb',
+  $systemd_template          = 'verdaccio/systemd.erb',
   $service_ensure            = 'running',
   $conf_max_body_size        = '1mb',
   $conf_max_age_in_sec       = '86400',
@@ -112,34 +113,52 @@ class verdaccio (
     }
   }
 
-  file { "${install_path}/daemon.log":
-    ensure  => present,
-    owner   => $daemon_user,
-    group   => $daemon_user,
-    require => File[$install_path],
-  }
-
   if $install_as_service {
-    $init_file = '/etc/init.d/verdaccio'
+    if $facts['systemd'] {
+      include ::systemd
 
-    file { $init_file:
-      content => template($service_template),
-      mode    => '0755',
-      notify  => $service_notify,
-    }
+      systemd::unit_file { 'verdaccio.service':
+        content => template($systemd_template),
+        enable  => true,
+      }
 
-    service { 'verdaccio':
-      ensure    => $service_ensure,
-      enable    => true,
-      hasstatus => true,
-      restart   => true,
-      require   => [
-        File[
-          $init_file,
-          "${install_path}/daemon.log"
+      service { 'verdaccio':
+        ensure  => $service_ensure,
+        enable  => true,
+        require => [
+          Systemd::Unit_file['verdaccio.service'],
+          Concat["${install_path}/config.yaml"]
         ],
-        Concat["${install_path}/config.yaml"],
-      ],
+      }
+    } else {
+      file { "${install_path}/daemon.log":
+        ensure  => present,
+        owner   => $daemon_user,
+        group   => $daemon_user,
+        require => File[$install_path],
+      }
+
+      $init_file = '/etc/init.d/verdaccio'
+
+      file { $init_file:
+        content => template($service_template),
+        mode    => '0755',
+        notify  => $service_notify,
+      }
+
+      service { 'verdaccio':
+        ensure    => $service_ensure,
+        enable    => true,
+        hasstatus => true,
+        restart   => true,
+        require   => [
+          File[
+            $init_file,
+            "${install_path}/daemon.log"
+          ],
+          Concat["${install_path}/config.yaml"],
+        ],
+      }
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
     {"name":"puppet/nodejs","version_requirement":">= 5.0.0 < 6.0.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"}
+    {"name":"puppetlabs-concat","version_requirement":">= 2.1.0"},
+    {"name":"camptocamp/systemd","version_requirement":">= 0.3.0 < 3.0.0"}
   ]
 }
 

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=Verdaccio lightweight npm proxy registry
+
+[Service]
+Type=simple
+Restart=on-failure
+User=verdaccio
+ExecStart=<%= @install_path %>/node_modules/verdaccio/bin/verdaccio --config <%= @install_path %>/config.yaml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This fixes the error "systemd[1]: verdaccio.service: New main PID xxx does not belong to service, and PID file is not owned by root. Refusing." when systemd tries to automatically convert the sysvinit file.

The systemd unit file template based on the one supplied by Verdaccio.