### PR TITLE
Make the npm package installation idempotent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,14 +75,14 @@ class verdaccio (
     true => Service['verdaccio']
   }
   $npm_ensure = $version ? {
-    undef => 'latest',
+    undef => 'present',
     default => $version
   }
   nodejs::npm { $package_name:
     ensure   => $npm_ensure,
     target   => $install_path,
     user     => $daemon_user,
-    home_dir => "/home/${daemon_user}/.npm",
+    home_dir => "/home/${daemon_user}",
     require  => [File[$install_path],User[$daemon_user]],
     notify   => $service_notify,
   }


### PR DESCRIPTION
Installing the 'latest' package triggers a change every time puppet agent runs.  This changes the default to 'present' so it installs the latest at the time of installation, and lets the admin choose to upgrade to subsequent versions at a time of their choosing.

It also fixes the home_dir setting, so a doubled .npm directory isn't created.
